### PR TITLE
Make fullscreen overlays cover display cutouts

### DIFF
--- a/app/src/main/java/com/playtranslate/PlayTranslateAccessibilityService.kt
+++ b/app/src/main/java/com/playtranslate/PlayTranslateAccessibilityService.kt
@@ -22,6 +22,7 @@ import android.view.WindowManager
 import android.view.accessibility.AccessibilityEvent
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.doOnLayout
 import com.playtranslate.ui.DimController
 import com.playtranslate.ui.OverlayAlert
 import com.playtranslate.ui.DragLookupController
@@ -330,13 +331,49 @@ class PlayTranslateAccessibilityService : AccessibilityService() {
         params: WindowManager.LayoutParams,
         displayId: Int,
     ): Boolean {
+        applyFullScreenOverlayDefaults(params)
         return try {
             wm.addView(view, params)
             overlayWindows += OverlayHandle(view, wm, params, displayId)
+            logOverlayGeometry(view, params, displayId)
             true
         } catch (e: Exception) {
             Log.w(TAG, "addOverlayWindow failed: ${e.message}")
             false
+        }
+    }
+
+    // One-shot diagnostic: verifies whether MATCH_PARENT overlay windows actually
+    // cover the full display. Investigating bonelag PR #9 — "OCR boxes pushed
+    // down" symptom is consistent with view origin != display origin or view
+    // dims != display dims. Grep with: adb logcat -s PlayTranslateA11y | grep Geometry
+    private fun logOverlayGeometry(
+        view: View,
+        params: WindowManager.LayoutParams,
+        displayId: Int,
+    ) {
+        val fullScreenParams =
+            params.width == WindowManager.LayoutParams.MATCH_PARENT &&
+                params.height == WindowManager.LayoutParams.MATCH_PARENT
+        if (!fullScreenParams) return
+        view.doOnLayout {
+            val display = getSystemService(DisplayManager::class.java)?.getDisplay(displayId)
+            val ds = Point().also { if (display != null) @Suppress("DEPRECATION") display.getRealSize(it) }
+            val loc = IntArray(2)
+            view.getLocationOnScreen(loc)
+            val name = view.javaClass.simpleName.ifBlank { "anon-View@${view.hashCode().toString(16)}" }
+            val flagBits = listOfNotNull(
+                "NO_LIMITS".takeIf { params.flags and WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS != 0 },
+                "IN_SCREEN".takeIf { params.flags and WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN != 0 },
+                "NOT_TOUCHABLE".takeIf { params.flags and WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE != 0 },
+            ).joinToString("|").ifEmpty { "none" }
+            val matches = view.width == ds.x && view.height == ds.y && loc[0] == 0 && loc[1] == 0
+            Log.i(
+                TAG,
+                "[Geometry] $name displayId=$displayId display=${ds.x}x${ds.y} " +
+                    "view=${view.width}x${view.height} origin=(${loc[0]},${loc[1]}) " +
+                    "matchesDisplay=$matches flags=$flagBits"
+            )
         }
     }
 
@@ -2031,7 +2068,34 @@ class PlayTranslateAccessibilityService : AccessibilityService() {
             displayId: Int,
         ): Boolean {
             instance?.let { return it.addOverlayWindow(view, wm, params, displayId) }
+            applyFullScreenOverlayDefaults(params)
             return try { wm.addView(view, params); true } catch (_: Exception) { false }
+        }
+
+        /**
+         * Defensive defaults for accessibility overlays that request the full
+         * display via MATCH_PARENT × MATCH_PARENT. Sets [FLAG_LAYOUT_NO_LIMITS]
+         * so the window isn't inset by system bars, and
+         * [LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS] so it isn't inset by display
+         * cutouts in portrait. Without these, a notch device reports a smaller
+         * view than the display, which silently miscalibrates OCR-box overlay
+         * coordinates (boxes drawn lower/right than the underlying text).
+         *
+         * Idempotent. Honors callers that explicitly set a non-DEFAULT
+         * cutout mode — only the DEFAULT case is upgraded.
+         */
+        private fun applyFullScreenOverlayDefaults(params: WindowManager.LayoutParams) {
+            val fullScreen =
+                params.width == WindowManager.LayoutParams.MATCH_PARENT &&
+                    params.height == WindowManager.LayoutParams.MATCH_PARENT
+            if (!fullScreen) return
+            params.flags = params.flags or WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS
+            if (params.layoutInDisplayCutoutMode ==
+                WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_DEFAULT
+            ) {
+                params.layoutInDisplayCutoutMode =
+                    WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS
+            }
         }
 
         fun removeOverlay(view: View, wm: WindowManager) {

--- a/app/src/main/java/com/playtranslate/ui/FloatingOverlayIcon.kt
+++ b/app/src/main/java/com/playtranslate/ui/FloatingOverlayIcon.kt
@@ -207,6 +207,18 @@ class FloatingOverlayIcon(context: Context) : View(context) {
     private val screenW: Int get() = queryScreenSize().x
     private val screenH: Int get() = queryScreenSize().y
 
+    /** Display-cutout safe insets in the icon's coordinate space. The icon's
+     *  window has [FLAG_LAYOUT_NO_LIMITS] so its origin is at the absolute
+     *  display origin (not the cutout-safe origin); on devices with a notch
+     *  this means snapping x=0 lands the icon behind the cutout. Edge-snap
+     *  code consults these insets so "Edge.LEFT" means "left of the safe
+     *  area" instead of "left of the display". */
+    private fun cutoutSafeInsetX(): Pair<Int, Int> {
+        val wm = overlayContext.getSystemService(WindowManager::class.java) ?: return 0 to 0
+        val cutout = wm.currentWindowMetrics.windowInsets.displayCutout ?: return 0 to 0
+        return cutout.safeInsetLeft to cutout.safeInsetRight
+    }
+
     private var velocityTracker: VelocityTracker? = null
     private var downRawX = 0f
     private var downRawY = 0f
@@ -505,7 +517,8 @@ class FloatingOverlayIcon(context: Context) : View(context) {
             else -> Edge.RIGHT
         }
 
-        val edgeCx = if (edge == Edge.LEFT) 0 else screenW
+        val (cutLeft, cutRight) = cutoutSafeInsetX()
+        val edgeCx = if (edge == Edge.LEFT) cutLeft else screenW - cutRight
         val targetX = edgeCx - viewHalf
 
         val targetCy: Int = if (hasFling && abs(xVel) > 1f) {
@@ -560,7 +573,8 @@ class FloatingOverlayIcon(context: Context) : View(context) {
         currentEdge = edge
         val f = if (fraction in 0f..1f) fraction else 0.5f
         val p = params ?: return
-        p.x = if (edge == Edge.LEFT) -viewHalf else screenW - viewHalf
+        val (cutLeft, cutRight) = cutoutSafeInsetX()
+        p.x = if (edge == Edge.LEFT) cutLeft - viewHalf else screenW - cutRight - viewHalf
         val cy = (minCy + f * (maxCy - minCy)).toInt().coerceIn(minCy, maxCy)
         p.y = cy - viewHalf
     }


### PR DESCRIPTION
## Summary
- Apply `FLAG_LAYOUT_NO_LIMITS` + `LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS` to every `MATCH_PARENT` accessibility overlay via a single helper on `addOverlayWindow` / `addOverlay`. Fixes OCR boxes rendering ~status-bar-height too low on display-cutout devices, and prevents per-call-site regressions for future overlays.
- Teach `FloatingOverlayIcon` edge-snap to read `DisplayCutout.safeInsetLeft/Right` so the icon lands at the safe-area boundary instead of behind the cutout.
- Add a `[Geometry]` `doOnLayout` diagnostic that logs `view.dims` vs `display.dims` for fullscreen overlays as a regression tripwire.

Inspired by #9, which surfaced the same bug; this PR takes the centralized-defaults route at the overlay chokepoint instead of per-site flag adds + a coordinate mapper. Reproduced on AYN Thor via `adb shell cmd overlay enable com.android.internal.display.cutout.emulation.tall`.