### PR TITLE
Apply production OCR crop and blackout to debug overlay

### DIFF
--- a/app/src/main/java/com/playtranslate/OverlayToolkit.kt
+++ b/app/src/main/java/com/playtranslate/OverlayToolkit.kt
@@ -457,6 +457,26 @@ object OverlayToolkit {
     )
 
     /**
+     * Compute the OCR input crop bounds for a raw screenshot. Single source of
+     * truth for the status-bar clamp — both [runOcrPipeline] (production) and
+     * [PlayTranslateAccessibilityService.runDebugCapture] (debug overlay) call
+     * this so they exclude the same pixel rows from ML Kit. Callers do their
+     * own [Bitmap.createBitmap] afterward to keep recycle ownership local.
+     */
+    fun computeOcrCrop(
+        rawWidth: Int,
+        rawHeight: Int,
+        activeRegion: RegionEntry,
+        statusBarHeight: Int,
+    ): Rect {
+        val top    = maxOf((rawHeight * activeRegion.top).toInt(), statusBarHeight)
+        val left   = (rawWidth  * activeRegion.left).toInt()
+        val bottom = (rawHeight * activeRegion.bottom).toInt()
+        val right  = (rawWidth  * activeRegion.right).toInt()
+        return Rect(left, top, right, bottom)
+    }
+
+    /**
      * Crop to active region, blackout floating icon, run OCR, filter source-lang chars.
      * Returns null if no text detected. Does NOT do dedup, translation, or display.
      */
@@ -469,20 +489,20 @@ object OverlayToolkit {
         iconRect: Rect?,
         compactIcon: Boolean
     ): OcrPipelineResult? {
-        val top    = maxOf((raw.height * activeRegion.top).toInt(), statusBarHeight)
-        val left   = (raw.width  * activeRegion.left).toInt()
-        val bottom = (raw.height * activeRegion.bottom).toInt()
-        val right  = (raw.width  * activeRegion.right).toInt()
-        val needsCrop = top > 0 || left > 0 || bottom < raw.height || right < raw.width
+        val crop = computeOcrCrop(raw.width, raw.height, activeRegion, statusBarHeight)
+        val needsCrop = crop.top > 0 || crop.left > 0 || crop.bottom < raw.height || crop.right < raw.width
         val bitmap = if (needsCrop)
-            Bitmap.createBitmap(raw, left, top, (right - left).coerceAtLeast(1), (bottom - top).coerceAtLeast(1))
+            Bitmap.createBitmap(raw, crop.left, crop.top, (crop.right - crop.left).coerceAtLeast(1), (crop.bottom - crop.top).coerceAtLeast(1))
         else raw
 
         val ocrResult: OcrManager.OcrResult?
         try {
-            val ocrBitmap = blackoutFloatingIcon(bitmap, left, top, iconRect, compactIcon)
-            ocrResult = ocrManager.recognise(ocrBitmap, sourceLang, screenshotWidth = raw.width)
-            if (ocrBitmap !== raw && ocrBitmap !== bitmap) ocrBitmap.recycle()
+            val ocrBitmap = blackoutFloatingIcon(bitmap, crop.left, crop.top, iconRect, compactIcon)
+            try {
+                ocrResult = ocrManager.recognise(ocrBitmap, sourceLang, screenshotWidth = raw.width)
+            } finally {
+                if (ocrBitmap !== raw && ocrBitmap !== bitmap) ocrBitmap.recycle()
+            }
         } finally {
             // Always clean up the crop (NOT raw — caller manages that)
             if (bitmap !== raw && !bitmap.isRecycled) bitmap.recycle()
@@ -493,7 +513,7 @@ object OverlayToolkit {
         val dedupKey = ocrResult.fullText.filter { c -> OcrManager.isSourceLangChar(c, sourceLang) }
         if (dedupKey.isEmpty()) return null
 
-        return OcrPipelineResult(ocrResult, dedupKey, left, top, raw.width, raw.height)
+        return OcrPipelineResult(ocrResult, dedupKey, crop.left, crop.top, raw.width, raw.height)
     }
 
     /**

--- a/app/src/main/java/com/playtranslate/PlayTranslateAccessibilityService.kt
+++ b/app/src/main/java/com/playtranslate/PlayTranslateAccessibilityService.kt
@@ -752,30 +752,61 @@ class PlayTranslateAccessibilityService : AccessibilityService() {
         val display = dm.getDisplay(displayId) ?: run { scheduleDebugCapture(); return }
 
         serviceScope.launch {
-            val bitmap = screenshotManager?.requestClean(displayId)
-            if (bitmap == null || !debugRunning) {
-                bitmap?.recycle()
+            val raw = screenshotManager?.requestClean(displayId)
+            if (raw == null || !debugRunning) {
+                raw?.recycle()
                 scheduleDebugCapture()
                 return@launch
             }
-            val screenshotW = bitmap.width
-            val screenshotH = bitmap.height
+            val screenshotW = raw.width
+            val screenshotH = raw.height
+
+            // Mirror the production OCR pipeline so the debug overlay shows
+            // what runOcrPipeline would see — same active region, same
+            // status-bar clamp, same floating-icon blackout. Falls back to
+            // a full-screen unclamped crop if the capture service isn't bound.
+            val captureSvc = CaptureService.instance
+            val region = captureSvc?.activeRegionForDisplay(displayId)
+                ?: RegionEntry("", 0f, 1f, 0f, 1f)
+            val statusBarHeight = captureSvc?.getStatusBarHeightForDisplay(displayId) ?: 0
+            val crop = OverlayToolkit.computeOcrCrop(raw.width, raw.height, region, statusBarHeight)
+            val needsCrop = crop.top > 0 || crop.left > 0 ||
+                crop.bottom < raw.height || crop.right < raw.width
+            val cropped = if (needsCrop) Bitmap.createBitmap(
+                raw, crop.left, crop.top,
+                (crop.right - crop.left).coerceAtLeast(1),
+                (crop.bottom - crop.top).coerceAtLeast(1),
+            ) else raw
 
             val ocr = debugOcrManager
             val result = try {
                 kotlinx.coroutines.withContext(Dispatchers.Default) {
-                    ocr.recognise(bitmap, SourceLanguageProfiles[prefs.sourceLangId].translationCode, collectDebugBoxes = true)
+                    val ocrBitmap = OverlayToolkit.blackoutFloatingIcon(
+                        cropped, crop.left, crop.top,
+                        getFloatingIconRect(displayId), prefs.compactOverlayIcon,
+                    )
+                    try {
+                        ocr.recognise(
+                            ocrBitmap,
+                            SourceLanguageProfiles[prefs.sourceLangId].translationCode,
+                            collectDebugBoxes = true,
+                            screenshotWidth = raw.width,
+                        )
+                    } finally {
+                        if (ocrBitmap !== raw && ocrBitmap !== cropped) ocrBitmap.recycle()
+                    }
                 }
             } catch (e: Exception) {
                 Log.w(TAG, "Debug OCR failed: ${e.message}")
                 null
             } finally {
-                bitmap.recycle()
+                if (cropped !== raw && !cropped.isRecycled) cropped.recycle()
+                raw.recycle()
             }
 
             val boxes = result?.debugBoxes
             if (boxes != null && debugRunning) {
-                showDebugOverlay(display, boxes, 0, 0, screenshotW, screenshotH)
+                showDebugOverlay(display, boxes, crop.left, crop.top, screenshotW, screenshotH)
             } else {
                 hideDebugOverlay()
             }


### PR DESCRIPTION
## Summary
- Extract `OverlayToolkit.computeOcrCrop` as a single source of truth for the status-bar clamp + region crop bounds. Call it from both `runOcrPipeline` (production) and `runDebugCapture` (debug overlay).
- Debug OCR now applies the same active-region crop, status-bar clamp, and floating-icon blackout as production, and passes `screenshotWidth` to ML Kit so group splitting matches. Previously the debug overlay drew red boxes for status-bar text that production correctly excluded.
- Wrap the `blackoutFloatingIcon` result in try/finally on both paths so the copy is recycled when `ocrManager.recognise` throws — pre-existing leak in `runOcrPipeline`; same shape would have been added to the debug path otherwise.

Discovered while reviewing #9: the debug-overlay path skipped the production clamp entirely, which is why ours and bonelag's overlays appeared to disagree on whether the status bar was "in OCR" — both pipelines see it in debug mode; only production excludes it via the clamp.