### PR TITLE
押して resolves to 押す · Te-form instead of the fossilized adverb

### DIFF
--- a/app/src/main/java/com/playtranslate/dictionary/DictionaryManager.kt
+++ b/app/src/main/java/com/playtranslate/dictionary/DictionaryManager.kt
@@ -120,6 +120,15 @@ class DictionaryManager private constructor(private val context: Context) {
     private val ukApplicableSupport = WeakHashMap<SQLiteDatabase, Boolean>()
     private val ukApplicableSupportLock = Any()
 
+    /** Per-handle capability cache for `headword.rank_score` — the KANJI-side
+     *  counterpart of [rankScoreSupport]. Gates [PhraseMembership.priorityHeadwords]:
+     *  a bare headword match isn't enough to admit a [Suspicion.CONVERB_CUT]
+     *  candidate (押して is a genuine but unranked headword) — only a headword
+     *  the pack ALSO ranks priority (`rank_score > 0`) may. Absent → fails
+     *  open to plain headword membership. */
+    private val headwordRankScoreSupport = WeakHashMap<SQLiteDatabase, Boolean>()
+    private val headwordRankScoreSupportLock = Any()
+
     /** All access to [rankScoreSupport] — read AND write — happens inside
      *  the lock. WeakHashMap's `get` can internally expunge stale entries,
      *  so even reads mutate the structure; serializing every operation
@@ -167,6 +176,15 @@ class DictionaryManager private constructor(private val context: Context) {
             keInfSupport[db]?.let { return it }
             val supports = checkColumnExists(db, "headword", "ke_inf")
             keInfSupport[db] = supports
+            return supports
+        }
+    }
+
+    private fun hasHeadwordRankScore(db: SQLiteDatabase): Boolean {
+        synchronized(headwordRankScoreSupportLock) {
+            headwordRankScoreSupport[db]?.let { return it }
+            val supports = checkColumnExists(db, "headword", "rank_score")
+            headwordRankScoreSupport[db] = supports
             return supports
         }
     }
@@ -282,6 +300,7 @@ class DictionaryManager private constructor(private val context: Context) {
         // matter which dictionary lists the string. See [Suspicion].
         val admissible = admissiblePhraseCandidates(
             candidates, membership.headwords, membership.kanaNativeReadings,
+            membership.priorityHeadwords,
         )
         var knownPhrases = membership.headwords + membership.readings
 
@@ -538,7 +557,11 @@ class DictionaryManager private constructor(private val context: Context) {
      * the caller can apply per-candidate [Suspicion] admissibility:
      *
      *  - [PhraseMembership.headwords] — matches a written form. Kanji surfaces
-     *    can't collide by pronunciation; always admissible.
+     *    can't collide by pronunciation; always admissible for a
+     *    [Suspicion.CONJUGATION_CUT] or [Suspicion.FUNCTION_RUN] candidate.
+     *  - [PhraseMembership.priorityHeadwords] — subset of [headwords] the
+     *    pack ALSO ranks as priority (`headword.rank_score > 0`). The ONLY
+     *    tier a [Suspicion.CONVERB_CUT] candidate may fuse from — see its doc.
      *  - [PhraseMembership.readings] — matches a PRIMARY reading
      *    (`rank_score >= 0`). The rank floor stops marginal positional
      *    readings (ここ+の → 九's position-2 counter stem, rank -20000).
@@ -550,26 +573,38 @@ class DictionaryManager private constructor(private val context: Context) {
      *
      * Each SQL variant is guarded by a probe for the columns IT dereferences
      * (Codex review find: rank_score's presence must not be trusted to imply
-     * uk_applicable, even though ja-v2 shipped them together). Degradation
-     * ladder on older/partial schemas: no `uk_applicable` → rank floor
-     * stays, kanaNativeReadings FAILS OPEN to the full reading set; no
-     * `rank_score` either → bare existence, everything fails open (degraded
-     * pre-v2 behavior, same precedent as the ranking SQL; such packs are
-     * force-upgraded). The [Suspicion.CONJUGATION_CUT] veto is structural and
-     * applies regardless of pack schema.
+     * uk_applicable, even though ja-v2 shipped them together). Missing columns
+     * fail open (bare existence / no priority floor) rather than crash —
+     * degraded but functional on older packs.
      */
     private fun batchCheckPhrases(db: SQLiteDatabase, candidates: Set<String>): PhraseMembership {
         if (candidates.isEmpty()) return PhraseMembership(emptySet(), emptySet(), emptySet())
         val ranked = hasRankScore(db)
         val tiered = ranked && hasUkApplicable(db)
+        val headwordRanked = hasHeadwordRankScore(db)
         val headwords = mutableSetOf<String>()
+        val priorityHeadwords = mutableSetOf<String>()
         val readings = mutableSetOf<String>()
         val kanaNative = mutableSetOf<String>()
         for (chunk in candidates.chunked(500)) {
             val placeholders = chunk.joinToString(",") { "?" }
             val args = chunk.toTypedArray()
-            db.rawQuery("SELECT DISTINCT text FROM headword WHERE text IN ($placeholders)", args)
-                .use { c -> while (c.moveToNext()) headwords.add(c.getString(0)) }
+            if (headwordRanked) {
+                db.rawQuery(
+                    "SELECT text, MAX(rank_score) FROM headword WHERE text IN ($placeholders) GROUP BY text",
+                    args,
+                ).use { c ->
+                    while (c.moveToNext()) {
+                        val text = c.getString(0)
+                        headwords.add(text)
+                        if (c.getInt(1) > 0) priorityHeadwords.add(text)
+                    }
+                }
+            } else {
+                db.rawQuery("SELECT DISTINCT text FROM headword WHERE text IN ($placeholders)", args)
+                    .use { c -> while (c.moveToNext()) headwords.add(c.getString(0)) }
+                priorityHeadwords.addAll(headwords)
+            }
             val remaining = chunk.filter { it !in headwords }
             if (remaining.isEmpty()) continue
             val ph2 = remaining.joinToString(",") { "?" }
@@ -596,7 +631,7 @@ class DictionaryManager private constructor(private val context: Context) {
                 }
             }
         }
-        return PhraseMembership(headwords, readings, kanaNative)
+        return PhraseMembership(headwords, readings, kanaNative, priorityHeadwords)
     }
 
     /** Query entries matching both a kanji form and a reading (narrowed
@@ -935,11 +970,25 @@ class DictionaryManager private constructor(private val context: Context) {
          * line start or after punctuation nothing can be severed, so
          * 、ていうか stays fusable), starts on glue bound to an incomplete stem
          * (いただい|ており, 言って|たな), is itself an incomplete stem plus its
-         * own glue (した, いない), or ends at an incomplete stem whose glue
-         * sits just outside the window (ことし|て, となり|ます). Vetoed
-         * outright: JMdict entries reachable only this way are conjugation
-         *-spanning grammar patterns (ないわけにはいかない) or reading
-         * coincidences — neither is a WORD the app is trying to surface.
+         * own AUXILIARY glue (した; see [CONVERB_CUT] for particle glue), or
+         * ends at an incomplete stem whose glue sits just outside the window
+         * (ことし|て, となり|ます). Vetoed outright: JMdict entries reachable
+         * only this way are conjugation-spanning grammar patterns
+         * (ないわけにはいかない) or reading coincidences — neither is a WORD the
+         * app is trying to surface.
+         *
+         * [CONVERB_CUT] — an incomplete content stem followed by PARTICLE
+         * glue only (押し|て, 従っ|て) — a fossilized-converb shape. Unlike
+         * CONJUGATION_CUT's auxiliary case (知ら+せる→知らせる, a real v1 verb
+         * that AGREES with the parse), JMdict genuinely lists exact joins of
+         * this shape as headwords (押して, adv "forcibly") that DISAGREE with
+         * it, so a written match needs the extra evidence of a priority tag
+         * before overriding the fallback. Measured over JMdict 3.6.2 ×
+         * SudachiDict-core (2889c7f8): of 800 headwords sharing the broader
+         * stem+glue shape, restricting to particle-only glue selects 207,
+         * none of which is a plain verb entry once the priority bar drops
+         * the unranked ones — the 593 auxiliary-glue forms are untouched.
+         *
          * "Incomplete" = 連用形/未然形/語幹 — forms that grammatically require
          * a continuation. 終止形-adjacent joins stay clean, which is what
          * keeps かもしれない matchable after 言われる.
@@ -953,34 +1002,42 @@ class DictionaryManager private constructor(private val context: Context) {
          * (との=殿, なん=南, にお=鳰). Grammar cannot make this call — it is
          * a fact about the lexicon, not the sentence.
          *
-         * Validated against the P5 500-line corpus (2026-08-28 A/B harness):
-         * 99/501 lines change, all garbage-removal; だから/でも/かな/
-         * かもしれない/ストレスかいしょう keep fusing.
+         * [CONJUGATION_CUT]/[FUNCTION_RUN] validated against the P5 500-line
+         * corpus (2026-08-28 A/B harness): 99/501 lines change, all
+         * garbage-removal; だから/でも/かな/かもしれない/ストレスかいしょう keep
+         * fusing.
          */
-        internal enum class Suspicion { CONJUGATION_CUT, FUNCTION_RUN }
+        internal enum class Suspicion { CONJUGATION_CUT, CONVERB_CUT, FUNCTION_RUN }
 
         /** Tiered phrase membership from [batchCheckPhrases] — see its doc. */
         internal data class PhraseMembership(
             val headwords: Set<String>,
             val readings: Set<String>,
             val kanaNativeReadings: Set<String>,
+            /** Subset of [headwords] the pack ALSO ranks as priority
+             *  (`headword.rank_score > 0`, i.e. carries a ke_pri tag). The
+             *  only tier a [Suspicion.CONVERB_CUT] candidate may fuse
+             *  from — see [admissiblePhraseCandidates]. */
+            val priorityHeadwords: Set<String> = emptySet(),
         )
 
         /**
          * Drop candidates whose [Suspicion] their membership tier can't
-         * license: conjugation cuts fuse only as written forms (in practice,
-         * never — their surfaces are kana); function runs additionally as
-         * kana-native readings. Clean candidates pass through. Pure; the
-         * matcher then needs no admissibility knowledge.
+         * license: converb cuts (押して) need a PRIORITY headword; conjugation
+         * cuts (した/知らせる) and function runs admit via any headword, plus a
+         * kana-native reading for function runs. Clean candidates pass
+         * through. Pure; the matcher then needs no admissibility knowledge.
          */
         internal fun admissiblePhraseCandidates(
             candidates: List<PhraseCandidate>,
             headwords: Set<String>,
             kanaNativeReadings: Set<String>,
+            priorityHeadwords: Set<String> = emptySet(),
         ): List<PhraseCandidate> = candidates.filter { c ->
             when (c.suspicion) {
                 null -> true
                 Suspicion.CONJUGATION_CUT -> c.lookupForm in headwords
+                Suspicion.CONVERB_CUT -> c.lookupForm in priorityHeadwords
                 Suspicion.FUNCTION_RUN ->
                     c.lookupForm in headwords || c.lookupForm in kanaNativeReadings
             }
@@ -1025,7 +1082,17 @@ class DictionaryManager private constructor(private val context: Context) {
             } else if (first.category.isContent && first.category.startsConjugation &&
                 first.hasIncompleteInflection && tokens[start + 1].category.isConjugationGlue
             ) {
-                return Suspicion.CONJUGATION_CUT
+                // PARTICLE-only glue disagrees with the parse about part of
+                // speech (押し|て); AUX glue derives a real word that agrees
+                // with it (知ら|せる→知らせる). See [Suspicion.CONVERB_CUT].
+                return if ((start + 1 until start + windowLen).all {
+                        tokens[it].category == JaCategory.PARTICLE
+                    }
+                ) {
+                    Suspicion.CONVERB_CUT
+                } else {
+                    Suspicion.CONJUGATION_CUT
+                }
             }
             val last = tokens[start + windowLen - 1]
             if (last.category.isContent && last.category.startsConjugation &&

--- a/app/src/test/java/com/playtranslate/dictionary/JaCategoryTest.kt
+++ b/app/src/test/java/com/playtranslate/dictionary/JaCategoryTest.kt
@@ -18,6 +18,29 @@ class JaCategoryTest {
 
     private fun cat(sub: String, norm: String) = JaCategory.fromUniDic("接尾辞", sub, norm)
 
+    /**
+     * TRIPWIRE. `動詞,非自立可能` marks a lemma CAPABLE of auxiliary use, not an
+     * occurrence that IS auxiliary — verified against sudachi 0.7.4: the main
+     * verb of 映画を見る, 机の上に本がある, 宿題をする and 彼が来る all carry it. So it
+     * must stay VERB and stay content: 18% of content tokens are tagged this
+     * way, and demoting them would silently empty the words panel via
+     * `DictionaryManager.contentOnlyTokens`, the single-token fallback, AND
+     * would corrupt [DictionaryManager.Companion.suspicionFor]'s content
+     * checks (a false-content verb reads as function-run glue) — none of
+     * which any other test covers, because every fixture hand-authors
+     * [JaCategory] literals.
+     */
+    @Test
+    fun `非自立可能 verbs stay content words`() {
+        for (lemma in listOf("見る", "ある", "する", "来る", "いる", "くれる", "しまう")) {
+            assertEquals(lemma, JaCategory.VERB, JaCategory.fromUniDic("動詞", "非自立可能", lemma))
+        }
+        assertEquals(true, JaCategory.fromUniDic("動詞", "非自立可能", "見る").isContent)
+        assertEquals(true, JaCategory.fromUniDic("動詞", "非自立可能", "見る").startsConjugation)
+        // 形容詞 carries it too (なけれ standalone), same rule.
+        assertEquals(JaCategory.ADJ_I, JaCategory.fromUniDic("形容詞", "非自立可能", "ない"))
+    }
+
     @Test
     fun `adjectival suffixes are i-adjectives`() {
         for (n in listOf("辛い", "難い", "易い", "ぽい", "臭い", "らしい")) {

--- a/app/src/test/java/com/playtranslate/dictionary/PhraseMembershipSqlTest.kt
+++ b/app/src/test/java/com/playtranslate/dictionary/PhraseMembershipSqlTest.kt
@@ -116,6 +116,50 @@ class PhraseMembershipSqlTest {
         assertEquals(setOf("ており"), found)
     }
 
+    // ── Priority-headword tier (Suspicion.CONVERB_CUT's admission bar) ────
+    // A CONVERB_CUT candidate may only fuse via a headword the pack ALSO
+    // ranks as priority (`headword.rank_score > 0`) — plain headword
+    // membership isn't enough (押して, adv "forcibly", is a genuine headword
+    // without a ke_pri tag).
+
+    /** Verbatim copy of `batchCheckPhrases`'s headword-rank query. */
+    private val HEADWORD_RANK_SQL =
+        "SELECT text, MAX(rank_score) FROM headword WHERE text IN (?, ?) GROUP BY text"
+
+    @Test fun `a headword without a priority tag is found but not priority`() {
+        val db = openDb()
+        // 押して (1852820): adv "forcibly" — a genuine headword, rank_score 0.
+        insertHeadword(db, entryId = 1852820, text = "押して", rankScore = 0)
+        // 知らせる (1361140): ichi1 — rank_score > 0.
+        insertHeadword(db, entryId = 1361140, text = "知らせる", rankScore = 1_000_000)
+
+        val found = mutableSetOf<String>()
+        val priority = mutableSetOf<String>()
+        db.rawQuery(HEADWORD_RANK_SQL, arrayOf("押して", "知らせる")).use { c ->
+            while (c.moveToNext()) {
+                val text = c.getString(0)
+                found.add(text)
+                if (c.getInt(1) > 0) priority.add(text)
+            }
+        }
+        assertEquals(setOf("押して", "知らせる"), found)
+        assertEquals(setOf("知らせる"), priority)
+    }
+
+    @Test fun `one priority row among homograph headwords is enough`() {
+        val db = openDb()
+        // MAX over rows: any priority-tagged homograph makes the text priority.
+        insertHeadword(db, entryId = 1, text = "した", rankScore = 0)
+        insertHeadword(db, entryId = 2, text = "した", rankScore = 1_000_000)
+
+        var maxRank = Int.MIN_VALUE
+        db.rawQuery(
+            "SELECT text, MAX(rank_score) FROM headword WHERE text IN (?) GROUP BY text",
+            arrayOf("した"),
+        ).use { c -> if (c.moveToNext()) maxRank = c.getInt(1) }
+        assertTrue(maxRank > 0)
+    }
+
     // ── Helpers ─────────────────────────────────────────────────────────
 
     private fun run(db: SQLiteDatabase, text: String): Pair<Set<String>, Set<String>> {
@@ -150,7 +194,8 @@ class PhraseMembershipSqlTest {
             CREATE TABLE headword (
                 entry_id INTEGER NOT NULL,
                 position INTEGER NOT NULL DEFAULT 0,
-                text TEXT NOT NULL
+                text TEXT NOT NULL,
+                rank_score INTEGER NOT NULL DEFAULT 0
             )
             """.trimIndent()
         )
@@ -164,7 +209,10 @@ class PhraseMembershipSqlTest {
         )
     }
 
-    private fun insertHeadword(db: SQLiteDatabase, entryId: Long, text: String) {
-        db.execSQL("INSERT INTO headword (entry_id, text) VALUES (?, ?)", arrayOf<Any>(entryId, text))
+    private fun insertHeadword(db: SQLiteDatabase, entryId: Long, text: String, rankScore: Int = 0) {
+        db.execSQL(
+            "INSERT INTO headword (entry_id, text, rank_score) VALUES (?, ?, ?)",
+            arrayOf<Any>(entryId, text, rankScore),
+        )
     }
 }

--- a/app/src/test/java/com/playtranslate/dictionary/ReglobTokensTest.kt
+++ b/app/src/test/java/com/playtranslate/dictionary/ReglobTokensTest.kt
@@ -833,16 +833,84 @@ class ReglobTokensTest {
     }
 
     @Test
-    fun `conjugation cut with a headword match stays admissible`() {
-        // The veto blocks reading coincidences, not written forms: a candidate
-        // whose joined surface matches a HEADWORD is admissible regardless.
+    fun `conjugation cut (auxiliary glue) stays admissible on a bare headword`() {
+        // した = し(する,連用形)+た(AUX) — auxiliary glue, not CONVERB_CUT.
         val tokens = listOf(
             jaToken("勝利", JaCategory.NOUN),
             jaToken("し", JaCategory.VERB, dict = "する", infl = "連用形-一般"),
             jaToken("た", JaCategory.AUX, infl = "終止形-一般"),
         )
+        assertEquals(Suspicion.CONJUGATION_CUT, exactSuspicion(tokens, "した"))
         val candidates = phraseCandidatesFor(tokens)
-        val admissible = admissiblePhraseCandidates(candidates, setOf("した"), emptySet())
+        val admissible = admissiblePhraseCandidates(candidates, headwords = setOf("した"), kanaNativeReadings = emptySet())
         assertTrue(admissible.any { it.lookupForm == "した" })
+    }
+
+    @Test
+    fun `auxiliary-glue derived verbs keep fusing without a priority tag`() {
+        // The priority floor must not reach 助動詞 chains deriving real words.
+        val shiraseru = listOf(
+            jaToken("知ら", JaCategory.VERB, dict = "知る", infl = "未然形-一般"),
+            jaToken("せる", JaCategory.AUX, dict = "せる"),
+        )
+        assertEquals(Suspicion.CONJUGATION_CUT, exactSuspicion(shiraseru, "知らせる"))
+        assertEquals(
+            "知らせる",
+            glob(shiraseru, knownPhrases = setOf("知らせる"))[0].lookupForm,
+        )
+
+        val kudaranai = listOf(
+            jaToken("下ら", JaCategory.VERB, dict = "下る", infl = "未然形-一般"),
+            jaToken("ない", JaCategory.AUX, dict = "ない"),
+        )
+        assertEquals(Suspicion.CONJUGATION_CUT, exactSuspicion(kudaranai, "下らない"))
+        assertEquals(
+            "下らない",
+            glob(kudaranai, knownPhrases = setOf("下らない"))[0].lookupForm,
+        )
+
+        // 済み+ませ+ん: an AUX anywhere in the glue run stays CONJUGATION_CUT.
+        val sumimasen = listOf(
+            jaToken("済み", JaCategory.VERB, dict = "済む", infl = "連用形-一般"),
+            jaToken("ませ", JaCategory.AUX, dict = "ます"),
+            jaToken("ん", JaCategory.AUX, dict = "ぬ"),
+        )
+        assertEquals(Suspicion.CONJUGATION_CUT, exactSuspicion(sumimasen, "済みません"))
+        assertEquals(
+            "済みません",
+            glob(sumimasen, knownPhrases = setOf("済みません"))[0].lookupForm,
+        )
+    }
+
+    @Test
+    fun `oshite fossilized adverb needs priority to override the te-form fallback`() {
+        // 押し(連用形)+て is PARTICLE-only glue: CONVERB_CUT, needing priority.
+        val tokens = listOf(
+            jaToken("押し", JaCategory.VERB, dict = "押す", infl = "連用形-一般"),
+            jaToken("て", JaCategory.PARTICLE, conj = true),
+        )
+        assertEquals(Suspicion.CONVERB_CUT, exactSuspicion(tokens, "押して"))
+        val admissible = admissiblePhraseCandidates(
+            phraseCandidatesFor(tokens), headwords = setOf("押して"), kanaNativeReadings = emptySet(),
+        )
+        assertTrue("without a priority tag, 押して stays inadmissible",
+            admissible.none { it.lookupForm == "押して" })
+        val r = reglobTokens(tokens, admissible, setOf("押して"), setOf("押す"))
+        assertEquals(listOf("押す"), r.map { it.lookupForm })
+        assertEquals("押して", r[0].surface)
+    }
+
+    @Test
+    fun `a priority-tagged converb headword clears the floor`() {
+        val tokens = listOf(
+            jaToken("従っ", JaCategory.VERB, dict = "従う", infl = "連用形-促音便"),
+            jaToken("て", JaCategory.PARTICLE, conj = true),
+        )
+        assertEquals(Suspicion.CONVERB_CUT, exactSuspicion(tokens, "従って"))
+        val admissible = admissiblePhraseCandidates(
+            phraseCandidatesFor(tokens), headwords = setOf("従って"), kanaNativeReadings = emptySet(),
+            priorityHeadwords = setOf("従って"),
+        )
+        assertTrue(admissible.any { it.lookupForm == "従って" })
     }
 }


### PR DESCRIPTION
## Summary

A priority floor on the `Suspicion.CONJUGATION_CUT` admission bar (`DictionaryManager.tokenizeWithSurfaces` → `admissiblePhraseCandidates`), split into its own `CONVERB_CUT` case so it applies only where it should.

`CONJUGATION_CUT` already vetoes windows shaped like a severed conjugation, but admits any candidate that matches a JMdict headword, with no floor on how common that headword actually is. 押して genuinely IS a headword (JMdict 1852820, adv "forcibly"), just without a `ke_pri` tag, so it still won over 押す's te-form.

This splits the shape into two cases instead of tightening admission uniformly:
- An inflected stem followed by **particle-only** glue (押し|て, 従っ|て) — `CONVERB_CUT` — is a fossilized-converb shape where the exact join and the single-token fallback describe the same text and *disagree* about part of speech, so it now needs a priority tag (`headword.rank_score > 0`) before overriding the fallback.
- An inflected stem followed by **auxiliary** glue (知ら|せる→知らせる, 下ら|ない→下らない, 済み|ませ|ん→済みません) derives a real dictionary word that *agrees* with the parse, so it keeps admitting on a bare headword match, unchanged.

That distinction isn't incidental — an earlier draft of this fix measured it directly (JMdict 3.6.2 × SudachiDict-core): of 800 headwords sharing the broader stem+glue shape, restricting the gate to particle-only glue selects 207; of the 186 that then fail the priority bar, none is a plain verb entry. The 593 auxiliary-glue forms keep their pre-gate behavior exactly.

## Before / after

| Sentence | Before | After |
|---|---|---|
| ボタンを押してゲームスタート | 押して shown as adverb "forcibly" (no priority tag) | 押す · Te-form |
| 従って (has a priority tag) | — | unaffected — still fuses, since the priority floor is cleared |
| 知らせる / 下らない / 済みません (auxiliary-glue derived) | fuse normally | still fuse normally — deliberately untouched |

## Test plan

- [x] Full JVM unit test suite passes (`./gradlew :app:testDebugUnitTest`)
- [x] `ReglobTokensTest`: 押して (converb-cut, needs priority), 従って (converb-cut, priority-tagged so still admits), auxiliary-glue guard set (知らせる/下らない/済みません — must NOT require priority)
- [x] `PhraseMembershipSqlTest`: SQL-level coverage for the new `headword.rank_score` priority tier
- [x] Installed and manually verified on-device (debug APK)